### PR TITLE
Add multiarch builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,19 +8,28 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,8 +7,10 @@ builds:
     id: nomad-vector-logger
     goos:
       - linux
+      - darwin
     goarch:
       - amd64
+      - arm64
     ldflags:
       - -s -w -X "main.buildString={{ .Tag }} ({{ .ShortCommit }} {{ .Date }})"
     dir: .
@@ -21,28 +23,10 @@ archives:
       - config.sample.toml
 
 dockers:
-  - # ID of the image, needed if you want to filter by it later on (e.g. on custom publishers).
-    id: nomad-vector-logger
-
-    # GOOS of the built binaries/packages that should be used.
-    goos: linux
-
-    # GOARCH of the built binaries/packages that should be used.
+  - image_templates: ["ghcr.io/mr-karan/nomad-vector-logger:{{ .Tag }}-amd64"]
     goarch: amd64
-
-    # IDs to filter the binaries/packages.
-    ids:
-      - nomad-vector-logger
-
-    # Templates of the Docker image names.
-    image_templates:
-      - "ghcr.io/mr-karan/nomad-vector-logger:{{ .Tag }}"
-      - "ghcr.io/mr-karan/nomad-vector-logger:latest"
-    
-    skip_push: false
     dockerfile: Dockerfile
-    use: docker
-    # Template of the docker build flags.
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -50,6 +34,28 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--platform=linux/amd64"
-
     extra_files:
       - config.sample.toml
+  - image_templates: ["ghcr.io/mr-karan/nomad-vector-logger:{{ .Tag }}-arm64"]
+    goarch: arm64
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--platform=linux/arm64"
+    extra_files:
+      - config.sample.toml
+
+docker_manifests:
+  - name_template: ghcr.io/mr-karan/nomad-vector-logger:{{ .Tag }}
+    image_templates:
+      - ghcr.io/mr-karan/nomad-vector-logger:{{ .Tag }}-amd64
+      - ghcr.io/mr-karan/nomad-vector-logger:{{ .Tag }}-arm64
+  - name_template: ghcr.io/mr-karan/nomad-vector-logger:latest
+    image_templates:
+      - ghcr.io/mr-karan/nomad-vector-logger:{{ .Tag }}-amd64
+      - ghcr.io/mr-karan/nomad-vector-logger:{{ .Tag }}-arm64


### PR DESCRIPTION
Updates goreleaser to build arm64 and amd64 builds for Linux and macOS, as well as linux/arm64 container images.