### PR TITLE
feat: add job type and parent job fields to allocation metadata

### DIFF
--- a/alloc.go
+++ b/alloc.go
@@ -123,6 +123,8 @@ func (app *App) generateConfig(allocs map[string]*api.Allocation) error {
 				Node:      alloc.NodeName,
 				Task:      task,
 				Job:       alloc.JobID,
+				JobType:   getStringOrEmpty(alloc.Job.Type),
+				ParentJob: getStringOrEmpty(alloc.Job.ParentID),
 			})
 		}
 	}
@@ -168,4 +170,11 @@ func (app *App) generateConfig(allocs map[string]*api.Allocation) error {
 	}
 
 	return nil
+}
+
+func getStringOrEmpty(str *string) string {
+	if str != nil {
+		return *str
+	}
+	return ""
 }

--- a/app.go
+++ b/app.go
@@ -39,6 +39,8 @@ type AllocMeta struct {
 	Task      string
 	Node      string
 	Group     string
+	JobType   string
+	ParentJob string
 }
 
 // Start initialises the subscription stream in background and waits

--- a/vector.toml.tmpl
+++ b/vector.toml.tmpl
@@ -15,5 +15,7 @@ source = '''
 .nomad.group_name = "{{$value.Group}}"
 .nomad.task_name = "{{$value.Task}}"
 .nomad.alloc_id = "{{$value.ID}}"
+.nomad.job_type = "{{$value.JobType}}"
+.nomad.parent_job_name = "{{$value.ParentJob}}"
 '''
 {{ end}}


### PR DESCRIPTION
Hi @mr-karan,

First, thanks for taking the time to build this! I've found it to be quite useful.

I run a lot of batch jobs via Nomad and the logging sinks tend to lose the context of the job their in. Nomad batch jobs all have a parent job. This PR adds the `JobType` and `ParentJob` labels which will allow us to properly configure downstream sinks for batch jobs.

- Added `JobType` and `ParentJob` fields to the `AllocMeta` struct in `app.go`
- Added the `job_type` and `parent_job_name` fields to the `vector.toml.tmpl` file